### PR TITLE
Hide password length in login cmd

### DIFF
--- a/cmd/authn.go
+++ b/cmd/authn.go
@@ -19,7 +19,7 @@ import (
 func newPasswordPrompt() *promptui.Prompt {
 	return &promptui.Prompt{
 		Label: "Please enter your password (it will not be echoed)",
-		Mask:  '*',
+		Mask:  ' ',
 	}
 }
 


### PR DESCRIPTION
### Desired Outcome

When typing in a password in the `login` command, hide the number of characters by not echoing any characters, even a `*`.

### Implemented Changes

This is achieved by setting the `prompt.Mask` property to a space (` `) (see https://github.com/manifoldco/promptui/pull/133)

### Connected Issue/Story

N/A