### PR TITLE
Add -H option for authenticate

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -72,16 +72,13 @@ func AuthenticatedConjurClientForCommand(cmd *cobra.Command) (ConjurClient, erro
 		return nil, err
 	}
 
-	var authenticator conjurapi.Authenticator
 	client, err := conjurapi.NewClientFromEnvironment(config)
 	decorateConjurClient(client)
-	if err == nil {
-		authenticator = client.GetAuthenticator()
-	} else {
+	if err != nil {
 		cmd.Printf("warn: %s\n", err)
 	}
 
-	if authenticator == nil {
+	if err == nil && client.GetAuthenticator() == nil {
 		client, err = conjurapi.NewClient(config)
 		if err != nil {
 			return nil, err

--- a/pkg/cmd/authenticate.go
+++ b/pkg/cmd/authenticate.go
@@ -2,47 +2,74 @@ package cmd
 
 import (
 	"encoding/base64"
+
 	"github.com/cyberark/conjur-cli-go/pkg/clients"
 	"github.com/cyberark/conjur-cli-go/pkg/utils"
 
 	"github.com/spf13/cobra"
 )
 
-var authenticateCmd = &cobra.Command{
-	Use:          "authenticate",
-	Short:        "Obtains an authentication token using the current logged-in user",
-	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		conjurClient, err := clients.AuthenticatedConjurClientForCommand(cmd)
-		if err != nil {
-			return err
-		}
+type authenticateClient interface {
+	InternalAuthenticate() ([]byte, error)
+}
 
-		//  TODO: I should be able to create an unauthenticated client, and then try to authenticate them using whatever is available!
-		data, err := conjurClient.InternalAuthenticate()
-		if err != nil {
-			return err
-		}
+func authenticateClientFactory(cmd *cobra.Command) (authenticateClient, error) {
+	return clients.AuthenticatedConjurClientForCommand(cmd)
+}
 
-		formatAsHeader, err := cmd.Flags().GetBool("header")
-		if err != nil {
-			return err
-		}
-		if formatAsHeader {
-			// Base64 encode the result and format as an HTTP Authorization header for the -H option
-			cmd.Println("Authorization: Token token=\"" + base64.StdEncoding.EncodeToString(data) + "\"")
-		} else {
-			if prettyData, err := utils.PrettyPrintJSON(data); err == nil {
-				data = prettyData
+type authenticateClientFactoryFunc func(*cobra.Command) (authenticateClient, error)
+
+// NewAuthenticateCommand creates an authenticate Command instance with injected dependencies.
+func NewAuthenticateCommand(clientFactory authenticateClientFactoryFunc) *cobra.Command {
+	authenticateCmd := &cobra.Command{
+		Use:          "authenticate",
+		Short:        "Obtains an access token for the currently logged-in user.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conjurClient, err := clientFactory(cmd)
+			if err != nil {
+				return err
 			}
-			cmd.Println(string(data))
-		}
-		return nil
-	},
+
+			//  TODO: I should be able to create an unauthenticated client, and then try to authenticate them using whatever is available!
+			data, err := conjurClient.InternalAuthenticate()
+			if err != nil {
+				return err
+			}
+
+			formatAsHeader, err := cmd.Flags().GetBool("header")
+			if err != nil {
+				return err
+			}
+
+			if formatAsHeader {
+				// Base64 encode the result and format as an HTTP Authorization header for the -H option
+				cmd.Println("Authorization: Token token=\"" + base64.StdEncoding.EncodeToString(data) + "\"")
+				return nil
+			}
+
+			prettyData, err := utils.PrettyPrintJSON(data)
+			if err != nil {
+				return err
+			}
+
+			cmd.Println(string(prettyData))
+			return nil
+		},
+	}
+
+	authenticateCmd.Flags().BoolP(
+		"header",
+		"H",
+		false,
+		"Base64 encode the result and format as an HTTP Authorization header",
+	)
+
+	return authenticateCmd
 }
 
 func init() {
+	authenticateCmd := NewAuthenticateCommand(authenticateClientFactory)
+
 	rootCmd.AddCommand(authenticateCmd)
-	authenticateCmd.Flags().BoolP("header", "H", false,
-		"Base64 encode the result and format as an HTTP Authorization header")
 }

--- a/pkg/cmd/authenticate_test.go
+++ b/pkg/cmd/authenticate_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockAuthenticateClient struct {
+	internalAuthenticate func() ([]byte, error)
+}
+
+func (m mockAuthenticateClient) InternalAuthenticate() ([]byte, error) {
+	return m.internalAuthenticate()
+}
+
+var authenticateCmdTestCases = []struct {
+	name                 string
+	args                 []string
+	internalAuthenticate func() ([]byte, error)
+	clientFactoryError   error
+	assert               func(t *testing.T, stdout, stderr string, err error)
+}{
+	{
+		name: "display help",
+		args: []string{"authenticate", "--help"},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			assert.Contains(t, stdout, "HELP LONG")
+		},
+	},
+	{
+		name: "json response",
+		args: []string{"authenticate"},
+		internalAuthenticate: func() ([]byte, error) {
+			return []byte(`{"user":"test"}`), nil
+		},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			expectedOut := `{
+  "user": "test"
+}
+`
+
+			assert.Contains(t, stdout, expectedOut)
+		},
+	},
+	{
+		name: "non-json response",
+		args: []string{"authenticate"},
+		internalAuthenticate: func() ([]byte, error) {
+			return []byte(`not json response`), nil
+		},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			assert.Contains(t, stderr, "Error: invalid")
+		},
+	},
+	{
+		name: "header format: json response",
+		args: []string{"authenticate", "-H"},
+		internalAuthenticate: func() ([]byte, error) {
+			return []byte(`{"user":"test"}`), nil
+		},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			expectedOut := `Authorization: Token token="eyJ1c2VyIjoidGVzdCJ9"
+`
+
+			assert.Contains(t, stdout, expectedOut)
+		},
+	},
+	{
+		name: "header format: non json response",
+		args: []string{"authenticate", "-H"},
+		internalAuthenticate: func() ([]byte, error) {
+			return []byte(`non json response`), nil
+		},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			expectedOut := `Authorization: Token token="bm9uIGpzb24gcmVzcG9uc2U="
+`
+
+			assert.Contains(t, stdout, expectedOut)
+		},
+	},
+	{
+		name: "client error",
+		args: []string{"authenticate"},
+		internalAuthenticate: func() ([]byte, error) {
+			return nil, fmt.Errorf("%s", "an error")
+		},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			assert.Contains(t, stderr, "Error: an error\n")
+		},
+	},
+	{
+		name:               "client factory error",
+		args:               []string{"authenticate"},
+		clientFactoryError: fmt.Errorf("%s", "client factory error"),
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			assert.Contains(t, stderr, "Error: client factory error\n")
+		},
+	},
+}
+
+func TestAuthenticateCmd(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range authenticateCmdTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testWhoamiClientFactory := func(cmd *cobra.Command) (authenticateClient, error) {
+				return mockAuthenticateClient{internalAuthenticate: tc.internalAuthenticate}, tc.clientFactoryError
+			}
+			cmd := NewAuthenticateCommand(testWhoamiClientFactory)
+
+			stdout, stderr, err := executeCommandForTest(t, cmd, tc.args...)
+			tc.assert(t, stdout, stderr, err)
+		})
+	}
+}

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -23,8 +23,10 @@ func whoamiClientFactory(cmd *cobra.Command) (whoamiClient, error) {
 	return clients.AuthenticatedConjurClientForCommand(cmd)
 }
 
+type whoamiClientFactoryFunc func(*cobra.Command) (whoamiClient, error)
+
 // NewWhoamiCommand creates a Command instance with injected dependencies.
-func NewWhoamiCommand(clientFactory func(*cobra.Command) (whoamiClient, error)) *cobra.Command {
+func NewWhoamiCommand(clientFactory whoamiClientFactoryFunc) *cobra.Command {
 	return &cobra.Command{
 		Use:          "whoami",
 		Short:        "Displays info about the logged in user",


### PR DESCRIPTION
### Desired Outcome

Conjur-cli-go should have the -H option for authenticate to be used in scripting.

for example - 
curl -H "$(conjur authenticate -H)" \
     --data "c3c60d3f266074" \
     https://eval.conjur.org/secrets/myorg/variable/prod/db/password


### Implemented Changes

Base64 encode the result and format as an HTTP Authorization header with the --HTTP option.
Unit tests will be added along when all the tests are added for authenticate.go in a separate PR.

### Connected Issue/Story


### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
