### PR TITLE
Implements resource show command in CLI

### DIFF
--- a/pkg/cmd/resource_test.go
+++ b/pkg/cmd/resource_test.go
@@ -17,13 +17,15 @@ func (m mockResourceClient) Resource(resourceID string) (resource map[string]int
 	return m.resource(m.t, resourceID)
 }
 
-var resourceExistsCmdTestCases = []struct {
+type resourceCmdTestCase struct {
 	name               string
 	args               []string
 	resource           func(t *testing.T, resourceID string) (resource map[string]interface{}, err error)
 	clientFactoryError error
 	assert             func(t *testing.T, stdout string, stderr string, err error)
-}{
+}
+
+var resourceExistsCmdTestCases = []resourceCmdTestCase{
 	{
 		name: "resource exists help",
 		args: []string{"exists", "--help"},
@@ -82,12 +84,88 @@ var resourceExistsCmdTestCases = []struct {
 	},
 }
 
+var resourceShowCmdTestCases = []resourceCmdTestCase{
+	{
+		name: "resource show help",
+		args: []string{"show", "--help"},
+		assert: func(t *testing.T, stdout string, stderr string, err error) {
+			assert.Contains(t, stdout, "HELP LONG")
+		},
+	},
+	{
+		name: "resource show missing resource-id",
+		args: []string{"show"},
+		assert: func(t *testing.T, stdout string, stderr string, err error) {
+			assert.Contains(t, stdout, "HELP LONG")
+		},
+	},
+	{
+		name: "resource show return object in pretty format",
+		args: []string{"show", "meow"},
+		resource: func(t *testing.T, resourceID string) (resource map[string]interface{}, err error) {
+			assert.Equal(t, "meow", resourceID)
+
+			return map[string]interface{}{"key": "value"}, nil
+		},
+		assert: func(t *testing.T, stdout string, stderr string, err error) {
+			assert.Contains(t, stdout, "{\n  \"key\": \"value\"\n}\n")
+		},
+	},
+	{
+		name: "resource show return object not found",
+		args: []string{"show", "meow"},
+		resource: func(t *testing.T, resourceID string) (resource map[string]interface{}, err error) {
+			assert.Equal(t, "meow", resourceID)
+
+			return nil, fmt.Errorf("%s", "an error")
+		},
+		assert: func(t *testing.T, stdout string, stderr string, err error) {
+			assert.Contains(t, stderr, "Error: an error\n")
+		},
+	},
+	{
+		name: "resource show client error",
+		args: []string{"show", "abcdefg"},
+		resource: func(t *testing.T, resourceID string) (resource map[string]interface{}, err error) {
+			return nil, fmt.Errorf("%s", "an error")
+		},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			assert.Contains(t, stderr, "Error: an error\n")
+		},
+	},
+	{
+		name:               "resource show client factory error",
+		args:               []string{"show", "abcdefg"},
+		clientFactoryError: fmt.Errorf("%s", "client factory error"),
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			assert.Contains(t, stderr, "Error: client factory error\n")
+		},
+	},
+}
+
 func TestResourceExistsCmd(t *testing.T) {
 	for _, tc := range resourceExistsCmdTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := mockResourceClient{t: t, resource: tc.resource}
 
 			cmd := newResourceExistsCmd(
+				func(cmd *cobra.Command) (resourceClient, error) {
+					return mockClient, tc.clientFactoryError
+				},
+			)
+
+			stdout, stderr, err := executeCommandForTest(t, cmd, tc.args...)
+			tc.assert(t, stdout, stderr, err)
+		})
+	}
+}
+
+func TestResourceShowCmd(t *testing.T) {
+	for _, tc := range resourceShowCmdTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := mockResourceClient{t: t, resource: tc.resource}
+
+			cmd := newResourceShowCmd(
 				func(cmd *cobra.Command) (resourceClient, error) {
 					return mockClient, tc.clientFactoryError
 				},


### PR DESCRIPTION
### Desired Outcome

This pull request produces a fully functional 'resource show' command for the Conjur CLI - Golang version.

### Implemented Changes

- Added 'resource show' as a new command
- Updated resource_tests to test full API & CLI functionality of command

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog (need a Changelog)

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
