### PR TITLE
Add OIDC multi-user E2E tests

### DIFF
--- a/ci/keycloak/users.yml
+++ b/ci/keycloak/users.yml
@@ -1,4 +1,5 @@
 - !user alice@conjur.net
+- !user bob@conjur.net
 
 - !policy
   id: keycloak
@@ -8,10 +9,17 @@
       annotations:
         authn-oidc/identity: 'alice@conjur.net'
 
+    - !user
+      id: bob.somebody
+      annotations:
+        authn-oidc/identity: 'bob@conjur.net'
+
 - !grant
   members:
     - !user alice@conjur.net
     - !user alice@keycloak
+    - !user bob.somebody@keycloak
+    - !user bob@conjur.net
   role: !group conjur/authn-oidc/keycloak/authenticatable
 
 - !permit

--- a/cmd/integration/integration_test.go
+++ b/cmd/integration/integration_test.go
@@ -57,6 +57,11 @@ func TestIntegration(t *testing.T) {
 		assertWhoamiCmd(t, err, stdOut, stdErr)
 	})
 
+	t.Run("authenticate", func(t *testing.T) {
+		stdOut, stdErr, err = conjurCLI.Run("authenticate")
+		assertAuthenticateCmd(t, err, stdOut, stdErr)
+	})
+
 	t.Run("get variable before policy load", func(t *testing.T) {
 		stdOut, stdErr, err = conjurCLI.Run("variable", "get", "-i", "meow")
 		assertNotFound(t, err, stdOut, stdErr)
@@ -72,15 +77,16 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("set variable after policy load", func(t *testing.T) {
 		stdOut, stdErr, err = conjurCLI.Run("variable", "set", "-i", "meow", "-v", "moo")
-		assert.NoError(t, err)
-		assert.Equal(t, "Value added\n", stdOut)
-		assert.Equal(t, "", stdErr)
+		assertSetVariableCmd(t, err, stdOut, stdErr)
 	})
 
 	t.Run("get variable after policy load", func(t *testing.T) {
 		stdOut, stdErr, err = conjurCLI.Run("variable", "get", "-i", "meow")
-		assert.NoError(t, err)
-		assert.Equal(t, "moo\n", stdOut)
-		assert.Equal(t, "", stdErr)
+		assertGetVariableCmd(t, err, stdOut, stdErr)
+	})
+
+	t.Run("logout", func(t *testing.T) {
+		stdOut, stdErr, err = conjurCLI.Run("logout")
+		assertLogoutCmd(t, err, stdOut, stdErr)
 	})
 }

--- a/cmd/integration/shared.go
+++ b/cmd/integration/shared.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package main
 
 import (
@@ -106,6 +109,14 @@ func assertWhoamiCmd(t *testing.T, err error, stdOut string, stdErr string) {
 	assert.Equal(t, "", stdErr)
 }
 
+func assertAuthenticateCmd(t *testing.T, err error, stdOut string, stdErr string) {
+	assert.NoError(t, err)
+	assert.Contains(t, stdOut, "protected")
+	assert.Contains(t, stdOut, "payload")
+	assert.Contains(t, stdOut, "signature")
+	assert.Equal(t, "", stdErr)
+}
+
 func assertNotFound(t *testing.T, err error, stdOut string, stdErr string) {
 	assert.Error(t, err)
 	assert.Equal(t, "", stdOut)
@@ -117,4 +128,22 @@ func assertPolicyLoadCmd(t *testing.T, err error, stdOut string, stdErr string) 
 	assert.Contains(t, stdOut, "created_roles")
 	assert.Contains(t, stdOut, "version")
 	assert.Equal(t, "Loaded policy 'root'\n", stdErr)
+}
+
+func assertSetVariableCmd(t *testing.T, err error, stdOut string, stdErr string) {
+	assert.NoError(t, err)
+	assert.Equal(t, "Value added\n", stdOut)
+	assert.Equal(t, "", stdErr)
+}
+
+func assertGetVariableCmd(t *testing.T, err error, stdOut string, stdErr string) {
+	assert.NoError(t, err)
+	assert.Equal(t, "moo\n", stdOut)
+	assert.Equal(t, "", stdErr)
+}
+
+func assertLogoutCmd(t *testing.T, err error, stdOut string, stdErr string) {
+	assert.NoError(t, err)
+	assert.Contains(t, stdOut, "Logged out\n")
+	assert.Equal(t, "", stdErr)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.19
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
-	github.com/cyberark/conjur-api-go v0.10.3-0.20221220184345-998b95c7b450 // Run "go get github.com/cyberark/conjur-api-go@main" to update
+	github.com/cyberark/conjur-api-go v0.10.3-0.20221222145454-566e7c46861d // Run "go get github.com/cyberark/conjur-api-go@main" to update
 	github.com/manifoldco/promptui v0.9.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/cyberark/conjur-api-go v0.10.3-0.20221220184345-998b95c7b450 h1:yF/3gcWiFp4hWOifOw2Xj7/E1QzYFuvHkd2zpvYuYFQ=
-github.com/cyberark/conjur-api-go v0.10.3-0.20221220184345-998b95c7b450/go.mod h1:8+qYC7L6wPY1e56hoZmHSdGa2fHALck8PtS+cUky75Y=
+github.com/cyberark/conjur-api-go v0.10.3-0.20221222145454-566e7c46861d h1:xgzz3pWXovmFfOUOXMTeuJJXfgQOBY6dsUdVOSc19vQ=
+github.com/cyberark/conjur-api-go v0.10.3-0.20221222145454-566e7c46861d/go.mod h1:8+qYC7L6wPY1e56hoZmHSdGa2fHALck8PtS+cUky75Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/clients/authn.go
+++ b/pkg/clients/authn.go
@@ -74,9 +74,9 @@ func oidcLogin(conjurClient ConjurClient, oidcPromptHandler func(string) error) 
 	}
 
 	// Refreshes the access token and caches it locally
-	err = conjurClient.RefreshToken()
+	err = conjurClient.ForceRefreshToken()
 	if err != nil {
-		return nil, err
+		return nil, errors.New("Unable to authenticate with Conjur. Please check your credentials.")
 	}
 
 	return conjurClient, nil

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -29,6 +29,7 @@ type ConjurClient interface {
 	PermittedRoles(resourceID, privilege string) ([]string, error)
 	ListOidcProviders() ([]conjurapi.OidcProvider, error)
 	RefreshToken() error
+	ForceRefreshToken() error
 	GetHttpClient() *http.Client
 }
 
@@ -73,10 +74,10 @@ func AuthenticatedConjurClientForCommand(cmd *cobra.Command) (ConjurClient, erro
 	client, err = conjurapi.NewClientFromEnvironment(config)
 	decorateConjurClient(client)
 	if err != nil {
-		cmd.Printf("warn: %s\n", err)
+		return nil, err
 	}
 
-	if err == nil && client.GetAuthenticator() == nil {
+	if client.GetAuthenticator() == nil {
 		client, err = conjurapi.NewClient(config)
 		if err != nil {
 			return nil, err

--- a/pkg/clients/oidc_callback_server.go
+++ b/pkg/clients/oidc_callback_server.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/browser"
 )
 
+var callbackServerTimeout = 5 * time.Minute
+
 type callbackEndpoint struct {
 	server         *http.Server
 	shutdownSignal chan string
@@ -99,7 +101,7 @@ func handleOpenIDFlow(authEndpointURL string, generateStateFn func() string, ope
 	}
 
 	// Set a timeout and shut down the server if we don't get a response in time
-	timeout := time.NewTimer(300 * time.Second)
+	timeout := time.NewTimer(callbackServerTimeout)
 	defer timeout.Stop()
 
 	select {


### PR DESCRIPTION
Depends on https://github.com/cyberark/conjur-api-go/pull/151

Add integration tests for handling OIDC authentication with multiple users (ie logging out, then logging in as another user) as well as OIDC users not in conjur and several other cases, and refactors integration tests. Also adds a unit test for the callback server timeout.