### PR TITLE
Rename 'verbose' to 'debug'

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -53,7 +53,7 @@ func LoadAndValidateConjurConfig() (conjurapi.Config, error) {
 func AuthenticatedConjurClientForCommand(cmd *cobra.Command) (ConjurClient, error) {
 	var err error
 
-	verbose, err := cmd.Flags().GetBool("verbose")
+	debug, err := cmd.Flags().GetBool("debug")
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func AuthenticatedConjurClientForCommand(cmd *cobra.Command) (ConjurClient, erro
 	// temporary Conjur client being created at that point in time. We should really not be creating so many Conjur clients
 	// we should just have one then the rest is an attempt to get an authenticator
 	decorateConjurClient := func(client ConjurClient) {
-		MaybeVerboseLoggingForClient(verbose, cmd, client)
+		MaybeDebugLoggingForClient(debug, cmd, client)
 	}
 
 	config, err := LoadAndValidateConjurConfig()

--- a/pkg/clients/debug.go
+++ b/pkg/clients/debug.go
@@ -8,13 +8,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// MaybeVerboseLoggingForClient optionally carries out verbose logging of HTTP requests and responses on a Conjur client
-func MaybeVerboseLoggingForClient(
-	verbose bool,
+// MaybeDebugLoggingForClient optionally carries out debug logging of HTTP requests and responses on a Conjur client
+func MaybeDebugLoggingForClient(
+	debug bool,
 	cmd *cobra.Command,
 	client ConjurClient,
 ) {
-	if !verbose {
+	if !debug {
 		return
 	}
 

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -26,7 +26,7 @@ var defaultLoginCmdFuncs = loginCmdFuncs{
 type loginCmdFlagValues struct {
 	username string
 	password string
-	verbose  bool
+	debug    bool
 }
 
 func getLoginCmdFlagValues(cmd *cobra.Command) (loginCmdFlagValues, error) {
@@ -42,7 +42,7 @@ func getLoginCmdFlagValues(cmd *cobra.Command) (loginCmdFlagValues, error) {
 		return loginCmdFlagValues{}, err
 	}
 
-	verbose, err := cmd.Flags().GetBool("verbose")
+	debug, err := cmd.Flags().GetBool("debug")
 	if err != nil {
 		return loginCmdFlagValues{}, err
 	}
@@ -50,7 +50,7 @@ func getLoginCmdFlagValues(cmd *cobra.Command) (loginCmdFlagValues, error) {
 	return loginCmdFlagValues{
 		username: username,
 		password: password,
-		verbose:  verbose,
+		debug:    debug,
 	}, nil
 }
 
@@ -88,8 +88,8 @@ Examples:
 				return err
 			}
 
-			if cmdFlagVals.verbose {
-				clients.MaybeVerboseLoggingForClient(cmdFlagVals.verbose, cmd, conjurClient)
+			if cmdFlagVals.debug {
+				clients.MaybeDebugLoggingForClient(cmdFlagVals.debug, cmd, conjurClient)
 			}
 
 			if config.AuthnType == "" || config.AuthnType == "authn" || config.AuthnType == "ldap" {

--- a/pkg/cmd/login_test.go
+++ b/pkg/cmd/login_test.go
@@ -80,8 +80,8 @@ var loginTestCases = []struct {
 		},
 	},
 	{
-		name:         "login with verbose flag",
-		args:         []string{"--verbose", "login", "-u", "alice", "-p", "secret"},
+		name:         "login with debug flag",
+		args:         []string{"--debug", "login", "-u", "alice", "-p", "secret"},
 		conjurConfig: defaultConjurConfig,
 		loginWithPromptFallback: func(t *testing.T, decoratePrompt prompts.DecoratePromptFunc, client clients.ConjurClient, username string, password string) (*authn.LoginPair, error) {
 			// Perform the login request which should cause the HTTP request and response to be printed
@@ -90,7 +90,7 @@ var loginTestCases = []struct {
 		},
 		assert: func(t *testing.T, stdout, stderr string, err error) {
 			assert.NoError(t, err)
-			// Stderr should contain the verbose output which includes the HTTP request and response
+			// Stderr should contain the debug output which includes the HTTP request and response
 			assert.Contains(t, stderr, "GET /authn/dev/login")
 			assert.Contains(t, stdout, "Logged in")
 		},

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -13,7 +13,7 @@ func newRootCommand() *cobra.Command {
 		Long:  "Command-line toolkit for managing Conjur resources and performing common tasks.",
 	}
 
-	rootCmd.PersistentFlags().Bool("verbose", false, "Verbose logging enabled")
+	rootCmd.PersistentFlags().Bool("debug", false, "Debug logging enabled")
 	return rootCmd
 }
 


### PR DESCRIPTION
### Desired Outcome

This pull request renames the usage of 'verbose' to 'debug' to maintain consistency throughout the Ruby / Python CLIs.

### Implemented Changes

• Renamed all usages of 'verbose' to 'debug'

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes
