### PR TITLE
Insecure flag

### DIFF
--- a/cmd/integration/integration_test.go
+++ b/cmd/integration/integration_test.go
@@ -41,10 +41,10 @@ func TestIntegration(t *testing.T) {
 	})
 
 	t.Run("init", func(t *testing.T) {
-		stdOut, stdErr, err = conjurCLI.Run("init", "-a", account, "-u", "http://conjur", "--force")
+		stdOut, stdErr, err = conjurCLI.Run("init", "-a", account, "-u", "http://conjur", "-i", "--force")
 		assert.NoError(t, err)
 		assert.Equal(t, "Wrote configuration to "+tmpDir+"/.conjurrc\n", stdOut)
-		assert.Equal(t, "", stdErr)
+		assert.Equal(t, insecureModeWarning, stdErr)
 	})
 
 	t.Run("login", func(t *testing.T) {

--- a/cmd/integration/oidc_integration_test.go
+++ b/cmd/integration/oidc_integration_test.go
@@ -36,11 +36,11 @@ func TestOidcIntegrationKeycloak(t *testing.T) {
 			"-u", "http://conjur",
 			"-t", "oidc",
 			"--service-id", "keycloak",
-			"--force",
+			"-i", "--force",
 		)
 		assert.NoError(t, err)
 		assert.Equal(t, "Wrote configuration to "+tmpDir+"/.conjurrc\n", stdOut)
-		assert.Equal(t, "", stdErr)
+		assert.Equal(t, insecureModeWarning, stdErr)
 	})
 
 	t.Run("login", func(t *testing.T) {
@@ -173,11 +173,11 @@ func TestOidcIntegrationOkta(t *testing.T) {
 			"-u", "http://conjur",
 			"-t", "oidc",
 			"--service-id", "okta-2",
-			"--force",
+			"-i", "--force",
 		)
 		assert.NoError(t, err)
 		assert.Equal(t, "Wrote configuration to "+tmpDir+"/.conjurrc\n", stdOut)
-		assert.Equal(t, "", stdErr)
+		assert.Equal(t, insecureModeWarning, stdErr)
 	})
 
 	t.Run("login", func(t *testing.T) {

--- a/cmd/integration/shared.go
+++ b/cmd/integration/shared.go
@@ -18,6 +18,9 @@ import (
 
 const pathToBinary = "conjur"
 
+const insecureModeWarning = "Warning: Running the command with '--insecure' makes your system vulnerable to security attacks\n" +
+	"If you prefer to communicate with the server securely you must reinitialize the client in secure mode.\n"
+
 func newConjurCLI(homeDir string) *conjurCLI {
 	return &conjurCLI{
 		homeDir: homeDir,

--- a/dev/start
+++ b/dev/start
@@ -125,7 +125,7 @@ EOL
   if [ "$ENABLE_AUTHN_OIDC" = true ]; then
     echo "Setting up Conjur for OIDC"
     docker-compose exec cli-dev bash -c 'conjur logout
-conjur init --force -u http://conjur -a dev -t oidc --service-id keycloak
+conjur init --force -u http://conjur -i -a dev -t oidc --service-id keycloak
 conjur login -u alice -p alice'
   fi
 


### PR DESCRIPTION
Depends on #67 

### Desired Outcome

Add support for --insecure flag in the init command

### Implemented Changes

- Changed default behavior to disallow http-only URLs in conjur init
- Added --insecure flag to override this behavior and allow http-only urls

### Connected Issue/Story

CyberArk internal issue ID: ONYX-30120

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
