### PR TITLE
Allow use of -i/--id flag in login command for compatibility

### DIFF
--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -37,6 +37,15 @@ func getLoginCmdFlagValues(cmd *cobra.Command) (loginCmdFlagValues, error) {
 		return loginCmdFlagValues{}, err
 	}
 
+	// BEGIN COMPATIBILITY WITH PYTHON CLI
+	if username == "" {
+		username, err = cmd.Flags().GetString("id")
+		if err != nil {
+			return loginCmdFlagValues{}, err
+		}
+	}
+	// END COMPATIBILITY WITH PYTHON CLI
+
 	password, err := cmd.Flags().GetString("password")
 	if err != nil {
 		return loginCmdFlagValues{}, err
@@ -111,6 +120,11 @@ Examples:
 
 	cmd.Flags().StringP("username", "u", "", "")
 	cmd.Flags().StringP("password", "p", "", "")
+
+	// BEGIN COMPATIBILITY WITH PYTHON CLI
+	cmd.Flags().StringP("id", "i", "", "")
+	cmd.Flags().MarkDeprecated("id", "use -u/--username instead")
+	// END COMPATIBILITY WITH PYTHON CLI
 
 	return cmd
 }

--- a/pkg/cmd/login_test.go
+++ b/pkg/cmd/login_test.go
@@ -95,6 +95,44 @@ var loginTestCases = []struct {
 			assert.Contains(t, stdout, "Logged in")
 		},
 	},
+	// BEGIN COMPATIBILITY WITH PYTHON CLI
+	{
+		name:         "login with -i flag",
+		args:         []string{"login", "-i", "alice", "-p", "secret"},
+		conjurConfig: defaultConjurConfig,
+		loginWithPromptFallback: func(t *testing.T, decoratePrompt prompts.DecoratePromptFunc, client clients.ConjurClient, username string, password string) (*authn.LoginPair, error) {
+			// Assert on arguments
+			assert.Equal(t, "alice", username)
+			assert.Equal(t, "secret", password)
+
+			return &authn.LoginPair{}, nil
+		},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			assert.NoError(t, err)
+			assert.Contains(t, stdout, "deprecated")
+			assert.Contains(t, stdout, "use -u/--username instead")
+			assert.Contains(t, stdout, "Logged in")
+		},
+	},
+	{
+		name:         "login with --id flag",
+		args:         []string{"login", "--id", "alice", "-p", "secret"},
+		conjurConfig: defaultConjurConfig,
+		loginWithPromptFallback: func(t *testing.T, decoratePrompt prompts.DecoratePromptFunc, client clients.ConjurClient, username string, password string) (*authn.LoginPair, error) {
+			// Assert on arguments
+			assert.Equal(t, "alice", username)
+			assert.Equal(t, "secret", password)
+
+			return &authn.LoginPair{}, nil
+		},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			assert.NoError(t, err)
+			assert.Contains(t, stdout, "deprecated")
+			assert.Contains(t, stdout, "use -u/--username instead")
+			assert.Contains(t, stdout, "Logged in")
+		},
+	},
+	// END COMPATIBILITY WITH PYTHON CLI
 	{
 		name:         "login with oidc",
 		args:         []string{"login", "-u", "alice", "-p", "secret"},


### PR DESCRIPTION
### Desired Outcome

Allow the use of the -i/--id flag in the conjur login command instead of the new -u/--username flag to maintain backwards compatibility with the Python CLI. However, print a deprecation warning when this is used.

### Implemented Changes

- Added a deprecated flag for -u/--username
- Added unit tests that ensure the flag works and prints a deprecation message

### Connected Issue/Story

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
