### PR TITLE
Dockerize CLI with OIDC (POC)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.19-alpine
+
+EXPOSE 8888
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN go install ./cmd/conjur


### PR DESCRIPTION
### Desired Outcome

Add a thin docker wrapper for running the CLI (including OIDC compatibility)

### Implemented Changes

* Added alpine-based dockerfile
* Modifications to OIDC ad-hoc callback listener

NOTE: The OIDC implementation here only works when the docker host can open a browser and the docker run command includes port mapping. See the [spike for investigating these limitations](https://gist.github.com/gl-johnson/d8c04cc333c6bbfac244ab2577d933ff).
