### PR TITLE
Print newline after 'Wrote certificate' output

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -143,7 +143,7 @@ func runInitCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if config.SSLCertPath != "" {
-		cmd.Printf("Wrote certificate to %s", config.SSLCertPath)
+		cmd.Printf("Wrote certificate to %s\n", config.SSLCertPath)
 	}
 
 	err = writeConjurrc(

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -323,7 +323,7 @@ func assertCertWritten(t *testing.T, conjurrcInTmpDir string, stdout string) {
 	assert.Contains(t, string(data), "cert_file: "+expectedCertPath)
 
 	// Assert that certificate is written
-	assert.Contains(t, stdout, "Wrote certificate to "+expectedCertPath)
+	assert.Contains(t, stdout, "Wrote certificate to "+expectedCertPath+"\n")
 	data, _ = os.ReadFile(expectedCertPath)
 	assert.Contains(t, string(data), "-----BEGIN CERTIFICATE-----")
 }


### PR DESCRIPTION
### Desired Outcome

Noticed an output bug in @szh's recent demo.
The output of `conjur init` is missing a newline:
```
$ conjur init ...
Wrote certificate to ${file_a}Wrote configuration to ${file_b}
```

### Implemented Changes

Added a newline after 'Wrote certificate' output string, and included the newline in `assertCertWritten` function, which looks for the output string in stdout.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
