### PR TITLE
Allow hostfactory to create tokens with a CIDR subnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [8.0.4] - 2023-02-23
+
+### Fixed
+- Allow hostfactory cidrs to specify a subnet
+  [cyberark/conjur-cli-go#113](https://github.com/cyberark/conjur-cli-go/pull/113)
+
 ## [8.0.3] - 2023-02-21
 
 ### Fixed
@@ -44,7 +50,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Placeholder version to capture the reset of the repository
 
-[Unreleased]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.3...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.4...HEAD
+[8.0.4]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.3...v8.0.4
 [8.0.3]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.2...v8.0.3
 [8.0.2]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.1...v8.0.2
 [8.0.1]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.0...v8.0.1

--- a/pkg/cmd/hostfactory_test.go
+++ b/pkg/cmd/hostfactory_test.go
@@ -171,6 +171,28 @@ var hostfactoryCmdTestCases = []struct {
 		},
 	},
 	{
+		name: "token create with ip with subnet success",
+		args: []string{"hostfactory", "tokens", "create", "--duration", "5m", "--hostfactory-id", "cucumber_host_factory_factory",
+			"-c", "0.0.0.0/0,1.2.3.0/24"},
+		create: func(t *testing.T, duration string, hostFactory string, cidr []string, count int) ([]conjurapi.HostFactoryTokenResponse, error) {
+			assert.Equal(t, "5m", duration)
+			assert.Equal(t, "cucumber_host_factory_factory", hostFactory)
+			assert.Equal(t, []string{"0.0.0.0/0", "1.2.3.0/24"}, cidr)
+
+			return []conjurapi.HostFactoryTokenResponse{
+				{
+					Expiration: "2022-12-23T20:32:46Z",
+					Cidr:       []string{"0.0.0.0/0", "1.2.3.0/24"},
+					Token:      "1bfpyr3y41kb039ykpyf2hm87ez2dv9hdc3r5sh1n2h9z7j22mga2da",
+				},
+			}, nil
+		},
+		assert: func(t *testing.T, stdout, stderr string, err error) {
+			assert.Contains(t, stdout, "1bfpyr3y41kb039ykpyf2hm87ez2dv9hdc3r5sh1n2h9z7j22mga2da")
+			assert.Contains(t, stdout, "[\n      \"0.0.0.0/0\",\n      \"1.2.3.0/24\"\n    ]")
+		},
+	},
+	{
 		name: "token create negative duration flags",
 		args: []string{"hostfactory", "tokens", "create", "-i", "cucumber_host_factory_factory", "--duration-hours", "-10"},
 		assert: func(t *testing.T, stdout, stderr string, err error) {
@@ -194,14 +216,6 @@ var hostfactoryCmdTestCases = []struct {
 		},
 		assert: func(t *testing.T, stdout, stderr string, err error) {
 			assert.NoError(t, err)
-		},
-	},
-	{
-		name: "token create command error",
-		args: []string{"hostfactory", "tokens", "create", "--duration", "5m", "--hostfactory-id", "cucumber_host_factory_factory",
-			"-c", "0.0.0"},
-		assert: func(t *testing.T, stdout, stderr string, err error) {
-			assert.Contains(t, stderr, "invalid string being converted")
 		},
 	},
 	{


### PR DESCRIPTION
### Desired Outcome

Hostfactory should allow a subnet on the cidrs

### Implemented Changes

The Golang Cobra CLI checks to verify the IP address, but this
is too restrictive as we want to allow an IP address with no subnet and also an IP address with a subnet.
If there is no subnet supplied by the user, it defaults to /32.

Removed the use of IPSliceP() and changed to just a plain string.
The CLI will no longer validate the IP address.

### Connected Issue/Story


CyberArk internal issue ID: [ONYX-33513]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
