### PR TITLE
Prepare CLI for homebrew release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,7 +58,8 @@ checksum:
   name_template: 'SHA256SUMS.txt'
 
 brews:
-  - description: CyberArk Conjur command line interface (Golang)
+  - name: conjur-cli
+    description: CyberArk Conjur command line interface
     homepage: https://conjur.org
     url_template: https://github.com/cyberark/conjur-cli-go/releases/download/v{{.Env.VERSION}}/conjur-cli-go_{{.Env.VERSION}}_{{.Os}}_{{.Arch}}.tar.gz
     install: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,6 @@ step and promote the desired build from the master branch.
 1. Jenkins build parameters can be utilized to promote a successful release
    or manually trigger aditional releases as needed.
 1. Reference the [internal automated release doc](https://github.com/conjurinc/docs/blob/master/reference/infrastructure/automated_releases.md#release-and-promotion-process) for releasing and promoting.
+1. Copy the `conjur-cli.rb` homebrew formula output by goreleaser
+   to the [homebrew formula for Conjur CLI](https://github.com/cyberark/homebrew-tools/blob/main/conjur-cli.rb)
+   and submit a PR to update the version of Conjur-Cli available in brew.


### PR DESCRIPTION
### Desired Outcome

The Conjur CLI is currently generating a homebrew .rb file upon release, but it hasn't yet been added to the https://github.com/cyberark/homebrew-tools repository so it remains unavailable for installation with homebrew. This PR simply updates the name of the generated .rb file from `conjur-cli-go` to `conjur-cli` and adds a step to the release documentation to update it in the homebrew-tools repo. Once this is merged, upon the next release of the CLI we can publish to homebrew.

### Connected Issue/Story

CyberArk internal issue ID: CNJR-95

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
