### PR TITLE
Allow OIDC redirect url to use a configured port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - OIDC login now supports a custom redirect URL port
   [cyberark/conjur-cli-go#117](https://github.com/cyberark/conjur-cli-go/pull/117)
 
+### Fixed
+- Reject OIDC login if configured port is in use
+  [cyberark/conjur-cli-go#117](https://github.com/cyberark/conjur-cli-go/pull/117)
+
 ## [8.0.4] - 2023-03-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [8.0.5] - 2023-03-03
 
+### Changed
+- OIDC login now supports a custom redirect URL port
+  [cyberark/conjur-cli-go#117](https://github.com/cyberark/conjur-cli-go/pull/117)
+
 ## [8.0.4] - 2023-03-03
 
 ### Fixed

--- a/pkg/clients/oidc_callback_server_test.go
+++ b/pkg/clients/oidc_callback_server_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -16,15 +18,79 @@ var httpClient = &http.Client{
 	Timeout: 1 * time.Second,
 }
 
+var testCases = []struct {
+	name          string
+	redirectURI   string
+	expectedError string
+}{
+	{
+		name:        "Succeeds with port 8888",
+		redirectURI: "http://127.0.0.1:8888/callback",
+	},
+	{
+		name:        "Succeeds with random port",
+		redirectURI: fmt.Sprintf("http://127.0.0.1:%d/callback", randomPort()),
+	},
+	{
+		name:        "Succeeds with port 80",
+		redirectURI: "http://127.0.0.1:80/callback",
+	},
+	{
+		name:        "Default port is used if none is specified",
+		redirectURI: "http://127.0.0.1/callback",
+	},
+	{
+		name:          "Fails if redirect_uri path is wrong",
+		redirectURI:   "http://127.0.0.1:9999/incorrect_callback",
+		expectedError: "redirect_uri must be http://127.0.0.1[:port]/callback",
+	},
+	{
+		name:          "Fails if redirect_uri port is not an integer",
+		redirectURI:   "http://127.0.0.1:invalid/callback",
+		expectedError: "redirect_uri must be http://127.0.0.1[:port]/callback",
+	},
+	{
+		name:          "Fails if redirect_uri port is invalid",
+		redirectURI:   "http://127.0.0.1:65536/callback",
+		expectedError: "Port in redirect_uri must be between 1 and 65535",
+	},
+}
+
 func TestHandleOidcFlow(t *testing.T) {
+	callbackServerTimeout = 5 * time.Second
 	// Note: It may be good to use the httptest package here instead of starting a real server which may allow
 	// running the tests in parallel.
 
-	t.Run("Fails if redirect_uri is wrong", func(t *testing.T) {
-		_, err := handleOpenIDFlow("https://example.com?redirect_uri=http%3A%2F%2F127.0.0.1%3A9999%2Fcallback", generateState, openBrowser)
-		assert.ErrorContains(t, err, "redirect_uri must be http://127.0.0.1:8888/callback")
-		assert.False(t, isServerRunning())
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			http.DefaultServeMux = http.NewServeMux()
+			var code string
+			var serverError error
+			mockOpenBrowser := func(url string) error { return nil }
+			redirectURI := "https://example.com?redirect_uri=" + url.QueryEscape(tc.redirectURI)
+			go func() {
+				code, serverError = handleOpenIDFlow(redirectURI, mockGenerateState, mockOpenBrowser)
+			}()
+			// Wait for the server to start up asynchronously
+			time.Sleep(200 * time.Millisecond)
+
+			// Check that the server is or is not running
+			port := portFromURL(tc.redirectURI)
+			if tc.expectedError != "" {
+				assert.False(t, isServerRunning(port))
+				assert.ErrorContains(t, serverError, tc.expectedError)
+			} else {
+				assert.True(t, isServerRunning(port))
+				_, err := httpClient.Get(tc.redirectURI + "?code=1234&state=test-state")
+				assert.NoError(t, err)
+				// Wait for the server to stop
+				time.Sleep(100 * time.Millisecond)
+				assert.False(t, isServerRunning(port))
+				assert.Equal(t, "1234", code)
+				assert.NoError(t, serverError)
+			}
+		})
+	}
 
 	t.Run("Opens browser and listens for callback", func(t *testing.T) {
 		openBrowserCalled := false
@@ -38,31 +104,33 @@ func TestHandleOidcFlow(t *testing.T) {
 		http.DefaultServeMux = http.NewServeMux()
 		var code string
 		var serverError error
+		port := fmt.Sprint(randomPort())
+		redirectURI := "https://example.com?redirect_uri=http%3A%2F%2F127.0.0.1%3A" + port + "%2Fcallback"
 		go func() {
-			code, serverError = handleOpenIDFlow("https://example.com?redirect_uri=http%3A%2F%2F127.0.0.1%3A8888%2Fcallback", mockGenerateState, mockOpenBrowser)
+			code, serverError = handleOpenIDFlow(redirectURI, mockGenerateState, mockOpenBrowser)
 		}()
 		// Wait for the server to start up asynchronously
 		time.Sleep(1 * time.Second)
 		// Ensure the open browser function was called and the server is running
 		assert.True(t, openBrowserCalled)
-		assert.True(t, isServerRunning())
+		assert.True(t, isServerRunning(port))
 		// Make a request to the callback endpoint without a code...
-		resp, err := httpClient.Get("http://127.0.0.1:8888/callback?state=test-state")
+		resp, err := httpClient.Get("http://127.0.0.1:" + port + "/callback?state=test-state")
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		// ...or with the wrong state...
-		resp, err = httpClient.Get("http://127.0.0.1:8888/callback?code=1234&state=wrong-state")
+		resp, err = httpClient.Get("http://127.0.0.1:" + port + "/callback?code=1234&state=wrong-state")
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		// ...and finally with a code and the correct state
-		resp, err = httpClient.Get("http://127.0.0.1:8888/callback?code=1234&state=test-state")
+		resp, err = httpClient.Get("http://127.0.0.1:" + port + "/callback?code=1234&state=test-state")
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		content, _ := io.ReadAll(resp.Body)
 		assert.Contains(t, string(content), "Logged in successfully")
 		// Ensure server is shut down
 		time.Sleep(1 * time.Second)
-		assert.False(t, isServerRunning())
+		assert.False(t, isServerRunning(port))
 		// Ensure the code was returned
 		assert.Equal(t, "1234", code)
 		assert.NoError(t, serverError)
@@ -110,8 +178,10 @@ func TestHandleOidcFlow(t *testing.T) {
 		callbackServerTimeout = 1 * time.Second
 		// Start the local server
 		http.DefaultServeMux = http.NewServeMux()
+		port := fmt.Sprint(randomPort())
+		redirectURI := "https://example.com?redirect_uri=http%3A%2F%2F127.0.0.1%3A" + port + "%2Fcallback"
 		go func() {
-			handleOpenIDFlow("https://example.com?redirect_uri=http%3A%2F%2F127.0.0.1%3A8888%2Fcallback", mockGenerateState, mockOpenBrowser)
+			handleOpenIDFlow(redirectURI, mockGenerateState, mockOpenBrowser)
 		}()
 
 		// Wait for the server to start up asynchronously
@@ -120,13 +190,13 @@ func TestHandleOidcFlow(t *testing.T) {
 		assert.True(t, openBrowserCalled)
 		// Ensure server is shut down
 		time.Sleep(250 * time.Millisecond)
-		assert.False(t, isServerRunning())
+		assert.False(t, isServerRunning(port))
 	})
 }
 
-func isServerRunning() bool {
+func isServerRunning(port string) bool {
 	// Checks whether the server is running by attempting to connect to the port
-	conn, err := net.DialTimeout("tcp", "127.0.0.1:8888", 1*time.Second)
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 1*time.Second)
 	if err != nil {
 		return false
 	}
@@ -152,4 +222,20 @@ func runDummyServer() func() {
 
 func mockGenerateState() string {
 	return "test-state"
+}
+
+func randomPort() int {
+	return rand.Intn(65535-1024) + 1024
+}
+
+func portFromURL(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return ""
+	}
+
+	if u.Port() == "" {
+		return "80"
+	}
+	return u.Port()
 }


### PR DESCRIPTION
### Desired Outcome

In the OIDC login flow, allow the OIDC redirect url to use a custom port (other than 8888). This allows flexibility if the user has another process running on port 8888 or has it blocked for some other reason.

### Implemented Changes

- To determine what port to listen on, the CLI will parse the `redirect_uri` query parameter in the OIDC callback URL returned by Conjur List Authenticators endpoint.
- Unit tests added and reorganized

- After this is released, the CLI docs can be updated. Currently it says "For authentication to the Conjur CLI, the value is always http://127.0.0.1:8888/callback.". This can be changed to indicate that the port can be anything between 1 and 65535, but recommended between 1024 and 65535 based on [RFC 6056 section 3.2](https://www.rfc-editor.org/rfc/rfc6056#section-3.2)

### Connected Issue/Story

CyberArk internal issue ID: CONJSE-1637

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
