### PR TITLE
Remove netgo tag to fix Windows hosts file bug

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,8 +14,13 @@ builds:
   # Tag 'netgo' is a Go build tag that ensures a pure Go networking stack
   # in the resulting binary instead of using the default host's stack to
   # ensure a fully static artifact that has no dependencies.
+  # However, netgo on Windows has a bug that prevents it from using the
+  # machine's hosts file for DNS resolution. Therefore this tag must be
+  # omitted on Windows until the bug is fixed. See
+  # https://github.com/golang/go/issues/57757 and internal ticket
+  # CNJR-904 for more information.
   flags:
-  - -tags=netgo
+  - -tags={{ if ne .Os "windows" }}netgo{{ end }}
   - -a
   goos:
   - linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
-## [8.0.7] - 2023-04-17
+## [8.0.7] - 2023-04-18
+
+### Fixed
+- Fixed not using hosts file on Windows
+  [cyberark/conjur-cli-go#121](https://github.com/cyberark/conjur-cli-go/pull/121)
 
 ## [8.0.6] - 2023-04-17
 
@@ -72,7 +76,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Placeholder version to capture the reset of the repository
 
-[Unreleased]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.6...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.7...HEAD
+[8.0.7]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.6...v8.0.7
 [8.0.6]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.5...v8.0.6
 [8.0.5]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.4...v8.0.5
 [8.0.4]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.3...v8.0.4


### PR DESCRIPTION
### Desired Outcome

Conjur CLI should use Windows hosts file when present.

### Implemented Changes

`netgo` has a bug that prevents it from using the machine's hosts file on Windows. See https://github.com/golang/go/issues/57757.
This PR disables the `netgo` build flag. It can be reenabled once the above issue is fixed.

### Connected Issue/Story

CyberArk internal issue ID: CNJR-904

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
