### PR TITLE
Support non-TTY Stdin for Confirmation prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [8.0.8] - 2023-04-19
+
+### Fixed
+- Fixed piping input to `conjur init` confirmation prompts
+  [cyberark/conjur-cli-go#127](https://github.com/cyberark/conjur-cli-go/pull/127)
+
 ## [8.0.7] - 2023-04-18
 
 ### Fixed
@@ -76,7 +82,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Placeholder version to capture the reset of the repository
 
-[Unreleased]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.7...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.8...HEAD
+[8.0.8]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.7...v8.0.8
 [8.0.7]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.6...v8.0.7
 [8.0.6]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.5...v8.0.6
 [8.0.5]: https://github.com/cyberark/conjur-cli-go/compare/v8.0.4...v8.0.5

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/creack/pty v1.1.18
 	github.com/cyberark/conjur-api-go v0.10.3-0.20230217154521-e01f713716d2 // Run "go get github.com/cyberark/conjur-api-go@main" to update
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
+	github.com/mattn/go-isatty v0.0.8
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.1
@@ -27,7 +28,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
-	github.com/mattn/go-isatty v0.0.8 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect


### PR DESCRIPTION
### Desired Outcome

Being unable to pipe responses to prompts is a known shortcoming of Survey: https://github.com/go-survey/survey/issues/394. We frequently pipe 'yes' responses to CLI confirmation prompts, and this commit supports ONLY those cases.

### Implemented Changes

- `func basicConfirm(message string) bool`, which uses standard `fmt` functions to prompt and collect confirmation responses.
- Unit tests for confirmations use Pipe-based Stdin, instead of a PTY.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
