### PR TITLE
Build FIPS binary with UBI toolchain for amd64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,45 +7,48 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-- main: ./cmd/conjur
-  binary: conjur
-  env:
-  - CGO_ENABLED=0
-  # Tag 'netgo' is a Go build tag that ensures a pure Go networking stack
-  # in the resulting binary instead of using the default host's stack to
-  # ensure a fully static artifact that has no dependencies.
-  # However, netgo on Windows has a bug that prevents it from using the
-  # machine's hosts file for DNS resolution. Therefore this tag must be
-  # omitted on Windows until the bug is fixed. See
-  # https://github.com/golang/go/issues/57757 and internal ticket
-  # CNJR-904 for more information.
-  flags:
-  - -tags={{ if ne .Os "windows" }}netgo{{ end }}
-  - -a
-  goos:
-  - linux
-  - darwin
-  - windows
-  goamd64: 
-   - v1
-  # The `Tag` override is there to provide the git commit information in the
-  # final binary. See `Static long version tags` in the `Building` section
-  # of `CONTRIBUTING.md` for more information.
-  ldflags:
-    - -w
-    - -X "github.com/cyberark/conjur-cli-go/pkg/version.Tag={{ .ShortCommit }}"
-    - -X "github.com/cyberark/conjur-cli-go/pkg/version.Version={{ .Env.VERSION }}"
-  hooks:
-    post:
-      # Copy the binary out into the <dist> path, and give the copy the name we want
-      # in the release <extra_files>.
-      # e.g. Suppose a windows amd64 build generates a binary at
-      # path/to/binary.exe. This will be copied to
-      # path/to/../binary-windows_amd64.exe. The copy path can then be added to
-      # the release <extra_files> and will result in a release artifact with the name
-      # binary-windows_amd64.exe.
-      - mkdir -p "{{ dir .Path }}/../binaries"
-      - cp "{{ .Path }}" "{{ dir .Path }}/../binaries/conjur_{{ .Target }}{{ .Ext }}"
+  - main: ./cmd/conjur
+    binary: conjur
+    env:
+      - CGO_ENABLED=0
+    # Tag 'netgo' is a Go build tag that ensures a pure Go networking stack
+    # in the resulting binary instead of using the default host's stack to
+    # ensure a fully static artifact that has no dependencies.
+    # However, netgo on Windows has a bug that prevents it from using the
+    # machine's hosts file for DNS resolution. Therefore this tag must be
+    # omitted on Windows until the bug is fixed. See
+    # https://github.com/golang/go/issues/57757 and internal ticket
+    # CNJR-904 for more information.
+    flags:
+      - -tags={{ if ne .Os "windows" }}netgo{{ end }}
+      - -a
+    goos:
+      - linux
+      - darwin
+      - windows
+    goamd64:
+      - v1
+    # The `Tag` override is there to provide the git commit information in the
+    # final binary. See `Static long version tags` in the `Building` section
+    # of `CONTRIBUTING.md` for more information.
+    ldflags:
+      - -w
+      - -X "github.com/cyberark/conjur-cli-go/pkg/version.Tag={{ .ShortCommit }}"
+      - -X "github.com/cyberark/conjur-cli-go/pkg/version.Version={{ .Env.VERSION }}"
+    hooks:
+      post:
+        # Copy the separately-built FIPS binaries into the GoReleaser build directory
+        - cmd: sh -c "cp -Rf {{ dir .Path }}/../../fips/* {{ dir .Path }}/../"
+          output: true
+        # Copy the binary out into the <dist> path, and give the copy the name we want
+        # in the release <extra_files>.
+        # e.g. Suppose a windows amd64 build generates a binary at
+        # path/to/binary.exe. This will be copied to
+        # path/to/../binary-windows_amd64.exe. The copy path can then be added to
+        # the release <extra_files> and will result in a release artifact with the name
+        # binary-windows_amd64.exe.
+        - mkdir -p "{{ dir .Path }}/../binaries"
+        - cp "{{ .Path }}" "{{ dir .Path }}/../binaries/conjur_{{ .Target }}{{ .Ext }}"
 
 archives:
   - id: conjur-cli-go-archive
@@ -60,7 +63,7 @@ archives:
     wrap_in_directory: true
 
 checksum:
-  name_template: 'SHA256SUMS.txt'
+  name_template: "SHA256SUMS.txt"
 
 brews:
   - name: conjur-cli
@@ -81,8 +84,8 @@ nfpms:
     description: CyberArk Conjur command line interface (Golang)
     file_name_template: "{{.ProjectName}}_{{.Env.VERSION}}_{{.Arch}}"
     formats:
-    - deb
-    - rpm
+      - deb
+      - rpm
     homepage: https://conjur.org
     license: "Apache 2.0"
     maintainer: CyberArk Maintainers <conj_maintainers@cyberark.com>
@@ -101,4 +104,3 @@ release:
     - glob: CHANGELOG.md
     - glob: LICENSE
     - glob: dist/goreleaser/binaries
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-cli-go#142](https://github.com/cyberark/conjur-cli-go/pull/142)
 - Allow API key rotation for logged-in host
   [cyberark/conjur-cli-go#143](https://github.com/cyberark/conjur-cli-go/pull/143)
+- Make `amd64` binary FIPS compliant on FIPS-enabled systems
+  [cyberark/conjur-cli-go#145](https://github.com/cyberark/conjur-cli-go/pull/145)
 
 ## [8.0.10] - 2023-06-29
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as conjur-cli-go-builder
+
+ENV VERSION=""
+
+RUN microdnf update
+RUN microdnf install -y go-toolset git
+
+# Add the WORKDIR as a safe directory so git commands
+# can be run in containers using this image
+RUN git config --global --add safe.directory /github.com/cyberark/conjur-cli-go
+
+COPY builder_entrypoint.sh /builder_entrypoint.sh
+RUN chmod +x /builder_entrypoint.sh
+
+ENTRYPOINT ["/builder_entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ To stub out a new command, [use the cobra-cli tool](https://github.com/spf13/cob
 ## Transitioning from the docker based CLI to 8.x
 
 See the [transition guide](docs/UPGRADE_from_docker_based.md)
+
+## FIPS Compatibility
+
+The `amd64` binaries are built using RedHat's patched Go compiler and with
+`GOEXPERIMENT=boringcrypto`. When run on a FIPS-enabled system, the binary will
+use the OpenSSL FIPS module provided by the system. On non-FIPS systems, the
+binary will fall back to BoringCrypto.

--- a/bin/build_container_images
+++ b/bin/build_container_images
@@ -16,7 +16,7 @@ function main() {
     CONTAINER_IMAGE_AND_TAG="conjur-cli:$(project_version_with_commit)"
 
     # Build container image/s by copying binaries
-    # 
+    #
     echo "Building ${CONTAINER_IMAGE_AND_TAG} container image"
     docker build \
         --tag "${CONTAINER_IMAGE_AND_TAG}" \

--- a/bin/build_release
+++ b/bin/build_release
@@ -28,9 +28,16 @@ function main() {
     # Grep it to avoid Go binary dependency
     GO_VERSION="v$(grep "^\bgo\b" "${REPO_ROOT}/go.mod" | awk '{print $2}')"
 
+    docker build -f "${REPO_ROOT}/Dockerfile.builder" -t conjur-cli-go-builder .
+
+    # Compile FIPS binaries with RedHat UBI
+    docker run --rm \
+      --env VERSION="${VERSION}" \
+      --volume "${REPO_ROOT}:/${PROJECT_WD}" \
+      --workdir "/${PROJECT_WD}" \
+      conjur-cli-go-builder
 
     # Compile binaries with Go Releaser
-    #
     echo "Docker image for release build: ${GORELEASER_IMAGE}"
     docker run --rm \
       --env VERSION="${VERSION}" \
@@ -38,6 +45,7 @@ function main() {
       --volume "${REPO_ROOT}:/${PROJECT_WD}" \
       --workdir "/${PROJECT_WD}" \
       "${GORELEASER_IMAGE}" --clean "$@"
+
     echo "Releases built. Archives can be found in dist/goreleaser"
 }
 

--- a/bin/builder_entrypoint.sh
+++ b/bin/builder_entrypoint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+function main() {
+  local OUTPUT_DIR
+  OUTPUT_DIR='dist/fips'
+
+  local SHORT_COMMIT_HASH
+  SHORT_COMMIT_HASH="$(git rev-parse --short HEAD)"
+
+  go mod tidy
+
+  rm -rf "$OUTPUT_DIR"
+  mkdir -p "$OUTPUT_DIR/conjur-cli-go_linux_amd64_v1"
+
+  CGO_ENABLED=1 \
+  GOOS=linux \
+  GOARCH=amd64 \
+  GOEXPERIMENT=boringcrypto \
+  go build \
+    -ldflags "-w -X github.com/cyberark/conjur-cli-go/pkg/version.Tag=$SHORT_COMMIT_HASH -X main.version=${VERSION}" \
+    -o "$OUTPUT_DIR/conjur-cli-go_linux_amd64_v1/conjur" \
+    ./cmd/conjur/main.go
+}
+
+main "$@"


### PR DESCRIPTION
### Desired Outcome

Update Golang CLI to be FIPS compliant, which essentially requires updating it to use goboring.

### Implemented Changes

Added Dockerfile builder based on RedHat UBI, using RedHat's patched Go compiler to make use of system OpenSSL with FIPS if available, falling back to statically linked in GoBoring crypto.

### Connected Issue/Story

CyberArk internal issue ID: CNJR-2699

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
