### PR TITLE
Update busybox container image to 1.36.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox:1.36.0 as conjur-cli-go
+FROM busybox:1.36.1 as conjur-cli-go
 LABEL org.opencontainers.image.authors="CyberArk Software Ltd."
 
 ENTRYPOINT [ "/usr/local/bin/conjur" ]

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as conjur-cli-go-builder
 
 ENV VERSION=""
 
-RUN microdnf update
+RUN microdnf update -y
 RUN microdnf install -y go-toolset git
 
 # Add the WORKDIR as a safe directory so git commands


### PR DESCRIPTION
### Desired Outcome

Conjur CLI should find the required minimum system `glibc` version in order to run. Fixes the below dynamic linkage error.

![image](https://github.com/cyberark/conjur-cli-go/assets/5092339/ade6c286-20e9-4a1e-a1e5-dc99d4556048)

### Implemented Changes

* Updated `busybox` container image to 1.36.1
* Add missing -y flag to microdnf update command in amd64 FIPS builder

### Connected Issue/Story

CyberArk internal issue ID: N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
